### PR TITLE
그라운드 생성 및 내 그라운드 조회 수정

### DIFF
--- a/src/main/java/companion/challeculum/domains/ground/CreateGroundDTO.java
+++ b/src/main/java/companion/challeculum/domains/ground/CreateGroundDTO.java
@@ -19,6 +19,7 @@ public class CreateGroundDTO {
     LocalDate endAt;
     int missionFailLimit;
     List<Map<String, String>> missionList;
+    long createdBy;
 
 
 }

--- a/src/main/java/companion/challeculum/domains/ground/GroundController.java
+++ b/src/main/java/companion/challeculum/domains/ground/GroundController.java
@@ -18,7 +18,13 @@ public class GroundController {
     GroundService service;
 
     @PostMapping("/api/v1/ground")
-    void createGround(@RequestBody CreateGroundDTO createGroundDTO) {
+    void createGround(@RequestBody CreateGroundDTO createGroundDTO,
+                      Authentication authentication) {
+        if(authentication == null){
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로그인하지 않았습니다.");
+        }
+        long sessUserId = ((PrincipalDetails) authentication.getPrincipal()).getUser().getId();
+        createGroundDTO.setCreatedBy(sessUserId);
         service.createGround(createGroundDTO);
     }
 

--- a/src/main/java/companion/challeculum/domains/ground/GroundController.java
+++ b/src/main/java/companion/challeculum/domains/ground/GroundController.java
@@ -1,8 +1,12 @@
 package companion.challeculum.domains.ground;
 
+import companion.challeculum.security.PrincipalDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +33,17 @@ public class GroundController {
     @GetMapping("/api/v1/userground/{userId}")
     List<Map<String, Object>> getMyGrounds(@PathVariable long userId,
                                            @RequestParam int page,
-                                           @RequestParam(required = false) String status) {
+                                           @RequestParam(required = false) String status,
+                                           Authentication authentication) {
+        if(authentication == null){
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로그인하지 않았습니다.");
+        }
+        long sessUserId = ((PrincipalDetails) authentication.getPrincipal()).getUser().getId();
+        boolean hasAdminRole = authentication.getAuthorities().stream()
+                .anyMatch(r -> r.getAuthority().equals("ROLE_ADMIN"));
+        if(sessUserId != userId && !hasAdminRole){
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인이나 관리자만 확인 가능합니다.");
+        }
         return service.getMyGrounds(userId, page, status);
     }
 

--- a/src/main/resources/mybatis/mapper/ground-mapping.xml
+++ b/src/main/resources/mybatis/mapper/ground-mapping.xml
@@ -47,9 +47,9 @@
 
     <insert id="createGround" parameterType="creategrounddto">
         insert into ground (lecture_id, title, information, level,
-                            max_capacity, deposit, start_at, end_at, mission_fail_limit)
+                            max_capacity, deposit, start_at, end_at, mission_fail_limit, created_by)
         values (#{lectureId}, #{title}, #{information}, #{level},
-                #{maxCapacity}, #{deposit}, #{startAt}, #{endAt}, #{missionFailLimit})
+                #{maxCapacity}, #{deposit}, #{startAt}, #{endAt}, #{missionFailLimit}, #{createdBy})
     </insert>
 
     <insert id="addMissionsToGround" parameterType="java.util.List">


### PR DESCRIPTION
* 그라운드 생성시 로그인 요구
* 그라운드 생성시 그라운드 생성자를 `ground`의 새로운 컬럼 `created_by` 에 추가
* 내 그라운드 조회시 자기 그라운드만 볼 수 있도록 함
* 관리자는 내 그라운드 조회 API 를 통해 모든 유저의 그라운드를 조회할 수 있음.